### PR TITLE
update travis and pascaliSetup scripts

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
 
 # currently only test ontology on integration setups for pascali
-./pascali-setup.sh
+
+# Split $TRAVIS_REPO_SLUG into the owner and repository parts
+OIFS=$IFS
+IFS='/'
+read -r -a slugarray <<< "$TRAVIS_REPO_SLUG"
+SLUGOWNER=${slugarray[0]}
+SLUGREPO=${slugarray[1]}
+IFS=$OIFS
+
+export REPO_SITE=$SLUGOWNER
+
+. ./pascali-setup.sh

--- a/pascali-setup.sh
+++ b/pascali-setup.sh
@@ -7,11 +7,12 @@ set -e
 
 export SHELLOPTS
 
-#TODO: avoid hard coding. maybe get repo from TRAVIS_SLUG
-export REPO_SITE=pascaliUWat
+#default value is pascaliUWat. REPO_SITE may be set to other value for travis test purpose.
+export REPO_SITE="${REPO_SITE:-pascaliUWat}"
+
+echo "------ Downloading everthing from REPO_SITE: $REPO_SITE ------"
 
 CUR_DIR=$(pwd)
-
 
 ##### build checker-framework
 if [ -d $JSR308/checker-framework ] ; then


### PR DESCRIPTION
currently the travis script of Ontology is just a wrapper of `pascali-setup.sh` that testing the whether changes in ontology breaks the whole building process.

Originally `pascali-setup.sh` hard coding the REPO_SITE to `pascaliUWat`, which is not nice for developing purpose.

Changed it to downloading dependencies from $SLUGOWNER if it exists. Otherwise `pascaliUWat` would be used.