### PR TITLE
More statistic functions in Ontology

### DIFF
--- a/cronStatistic.sh
+++ b/cronStatistic.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+WORKING_DIR=$(cd $(dirname "$0") && pwd)
+
+#setup env variables
+. ./env-setup.sh
+
+export REPO_SITE=opprop 
+
+### building checker framework stuffs and ontology
+# . ./pascali-setup.sh
+
+
+### fetching annotated projects
+
+PROJECTS_DIR=$JSR308/annotatedProjects
+PROJECTS_DATA=$JSR308/ontology/projects.data
+
+##
+#$1: project_info, format is "project_gitUrl branch" or "project_url" which the master branch will be apply
+#do a light clone (depth 1) of a given git project to current directory
+function downloadGitProject() {
+
+    project_url=$1
+
+    if [ $# == "2" ]; then
+        branch=$2;
+    else
+        branch="master"
+    fi
+
+    git clone $project_url --branch $branch --depth=1
+} 
+
+function runOntologyOnProject() {
+    mvn="pom.xml"
+    gradle="build.gradle"
+    ant="build.xml"
+    # echo "project: $1"
+    cd $1
+    #determine build cmd
+    if [ -e $ant ]; then
+        build_cmd="ant"
+    elif [ -e $gradle ]; then
+        build_cmd="gradle"
+    elif [ -e $mvn ]; then
+        build_cmd="mvn install"
+    else
+        echo "don't know for $1"
+        return 1
+    fi
+
+    echo "$1 $build_cmd"
+    $JSR308/ontology/run-dljc.sh $build_cmd | tee ontology.log
+}
+
+# remove legacy projects
+if [ -d "$PROJECTS_DIR" ]; then
+    rm -rf "$PROJECTS_DIR"
+fi
+
+mkdir "$PROJECTS_DIR"
+
+cd $PROJECTS_DIR
+
+while read line
+do
+    downloadGitProject $line
+done < $PROJECTS_DATA
+
+for project in $PROJECTS_DIR/*
+do
+    runOntologyOnProject $project
+done
+
+### collecting statistics
+

--- a/projects.data
+++ b/projects.data
@@ -1,0 +1,3 @@
+https://github.com/CharlesZ-Chen/jReactPhysics3D.git annotated
+https://github.com/CharlesZ-Chen/ode4j.git annotated
+https://github.com/CharlesZ-Chen/dyn4j.git

--- a/src/ontology/qual/OntologyValue.java
+++ b/src/ontology/qual/OntologyValue.java
@@ -13,10 +13,10 @@ public enum OntologyValue {
 
     TOP("TOP"),
     SEQUENCE("sequence"),
-    POSITION_3D("3DPosition"),
-    VELOCITY_3D("3DVelocity"),
-    FORCE_3D("3DForce"),
-    TORQUE_3D("3DTorque"),
+    POSITION_3D("position_3d"),
+    VELOCITY_3D("velocity_3d"),
+    FORCE_3D("force_3d"),
+    TORQUE_3D("torque_3d"),
     BOTTOM("BOTTOM");
 
     private String value;

--- a/src/ontology/solvers/backend/OntologyConstraintSolver.java
+++ b/src/ontology/solvers/backend/OntologyConstraintSolver.java
@@ -2,6 +2,7 @@ package ontology.solvers.backend;
 
 import ontology.qual.OntologyValue;
 import ontology.util.OntologyStatisticUtil;
+import ontology.util.ViolatedConsDiagnostic;
 import ontology.util.OntologyUtils;
 
 import org.checkerframework.framework.type.QualifierHierarchy;
@@ -11,7 +12,6 @@ import org.checkerframework.javacutil.ErrorReporter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -288,40 +288,6 @@ public class OntologyConstraintSolver extends ConstraintSolver {
         GraphBuilder graphBuilder = new GraphBuilder(slots, constraints, SubtypeDirection.FROMSUBTYPE);
         ConstraintGraph constraintGraph = graphBuilder.buildGraph();
         return constraintGraph;
-    }
-
-    protected class ViolatedConsDiagnostic {
-        SubtypeConstraint subtypeConstraint;
-        AnnotationMirror inferredSubtype;
-        AnnotationMirror inferredSupertype;
-        List<AnnotationMirror> subtypeSolutions;
-        List<AnnotationMirror> supertypeSolutions;
-
-        public ViolatedConsDiagnostic(SubtypeConstraint subtypeConstraint,
-                AnnotationMirror subtype, AnnotationMirror supertype) {
-            this.subtypeConstraint = subtypeConstraint;
-            this.inferredSubtype = subtype;
-            this.inferredSupertype = supertype;
-            subtypeSolutions = Collections.emptyList();
-            supertypeSolutions = Collections.emptyList();
-        }
-
-        public void setSubtypeSolutions(List<AnnotationMirror> subtypeSolutions) {
-            this.subtypeSolutions = subtypeSolutions;
-        }
-
-        public void setSupertypeSolutions(List<AnnotationMirror> supertypeSolutions) {
-            this.supertypeSolutions = supertypeSolutions;
-        }
-
-        @Override
-        public String toString() {
-            return subtypeConstraint
-                    + "\tsubtype: " + inferredSubtype
-                    + "\tsupertype: " + inferredSupertype
-                    + "\t\n subtypeSolutions: " + subtypeSolutions
-                    + "\t\n supertypeSolutions: " + supertypeSolutions;
-        }
     }
 
     @Override

--- a/src/ontology/solvers/backend/OntologyConstraintSolver.java
+++ b/src/ontology/solvers/backend/OntologyConstraintSolver.java
@@ -1,6 +1,7 @@
 package ontology.solvers.backend;
 
 import ontology.qual.OntologyValue;
+import ontology.util.OntologyStatisticUtil;
 import ontology.util.OntologyUtils;
 
 import org.checkerframework.framework.type.QualifierHierarchy;
@@ -23,7 +24,6 @@ import java.util.concurrent.ExecutionException;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
 
-import util.PrintUtils;
 import checkers.inference.DefaultInferenceSolution;
 import checkers.inference.InferenceMain;
 import checkers.inference.InferenceSolution;
@@ -255,7 +255,7 @@ public class OntologyConstraintSolver extends ConstraintSolver {
             result.put(entry.getKey(), resultAnno);
         }
         result = inferMissingConstraint(result);
-        PrintUtils.printResult(result);
+        OntologyStatisticUtil.writeInferenceResult("ontology-inferred-slots-statistic.txt", result);
         return new DefaultInferenceSolution(result);
     }
 

--- a/src/ontology/solvers/backend/OntologyConstraintSolver.java
+++ b/src/ontology/solvers/backend/OntologyConstraintSolver.java
@@ -98,7 +98,13 @@ public class OntologyConstraintSolver extends ConstraintSolver {
 
         InferenceSolution mergedSolution = mergeSolution(inferenceSolutionMaps);
 
-        verifyMergedSolution(mergedSolution, constraints, qualHierarchy, inferenceSolutionMaps);
+        try {
+            verifyMergedSolution(mergedSolution, constraints, qualHierarchy, inferenceSolutionMaps);
+        } finally {
+            if (collectStatistic) {
+                OntologyStatisticUtil.getPostVerifyStatRecorder().writeStatistic();
+            }
+        }
 
         return mergedSolution;
     }
@@ -183,6 +189,7 @@ public class OntologyConstraintSolver extends ConstraintSolver {
                 consDiagRes.setSubtypeSolutions(subtypeSolutions);
                 consDiagRes.setSupertypeSolutions(supertypeSolutions);
                 diagnosticList.add(consDiagRes);
+                OntologyStatisticUtil.getPostVerifyStatRecorder().recordViolatedConsDiags(consDiagRes);
             }
         }
 
@@ -199,6 +206,7 @@ public class OntologyConstraintSolver extends ConstraintSolver {
     private void logNoSolution(SubtypeConstraint subtypeConstraint, AnnotationMirror subtype, AnnotationMirror supertype) {
         InferenceMain.getInstance().logger.warning("no solution for subtype constraint: " + subtypeConstraint +
                 "\tinferred subtype: " + subtype + "\tinferred supertype: " + supertype);
+        OntologyStatisticUtil.getPostVerifyStatRecorder().recordMissingSolution(subtypeConstraint);
     }
 
     private void addPreferenceToCurBottom(ConstantSlot curBtm, Set<Constraint> consSet) {
@@ -255,7 +263,11 @@ public class OntologyConstraintSolver extends ConstraintSolver {
             result.put(entry.getKey(), resultAnno);
         }
         result = inferMissingConstraint(result);
-        OntologyStatisticUtil.writeInferenceResult("ontology-inferred-slots-statistic.txt", result);
+
+        if (collectStatistic) {
+            OntologyStatisticUtil.writeInferenceResult("ontology-inferred-slots-statistic.txt", result);
+        }
+
         return new DefaultInferenceSolution(result);
     }
 

--- a/src/ontology/solvers/backend/OntologyConstraintSolver.java
+++ b/src/ontology/solvers/backend/OntologyConstraintSolver.java
@@ -111,7 +111,7 @@ public class OntologyConstraintSolver extends ConstraintSolver {
      */
     protected void verifyMergedSolution(InferenceSolution mergedSolution,
             Collection<Constraint> constraints, QualifierHierarchy qualifierHierarchy, List<Map<Integer, AnnotationMirror>> solutionMaps) {
-        List<ConstraintDiagnosticResult> diagnosticList = new ArrayList<>();
+        List<ViolatedConsDiagnostic> diagnosticList = new ArrayList<>();
 
         for (Constraint constraint : constraints) {
             if (!(constraint instanceof SubtypeConstraint)) {
@@ -166,7 +166,7 @@ public class OntologyConstraintSolver extends ConstraintSolver {
             assert subtype != null && supertype != null;
 
             if (!qualifierHierarchy.isSubtype(subtype, supertype)) {
-                ConstraintDiagnosticResult consDiagRes = new ConstraintDiagnosticResult(sConstraint, subtype, supertype);
+                ViolatedConsDiagnostic consDiagRes = new ViolatedConsDiagnostic(sConstraint, subtype, supertype);
 
                 List<AnnotationMirror> subtypeSolutions = new ArrayList<> ();
                 List<AnnotationMirror> supertypeSolutions = new ArrayList<> ();
@@ -189,7 +189,7 @@ public class OntologyConstraintSolver extends ConstraintSolver {
         if (!diagnosticList.isEmpty()) {
             StringBuilder sBuilder = new StringBuilder();
             sBuilder.append("solved solution doesn't consistent with below constraints: \n");
-            for (ConstraintDiagnosticResult result : diagnosticList) {
+            for (ViolatedConsDiagnostic result : diagnosticList) {
                 sBuilder.append(result + "\n");
             }
             ErrorReporter.errorAbort(sBuilder.toString());
@@ -290,14 +290,14 @@ public class OntologyConstraintSolver extends ConstraintSolver {
         return constraintGraph;
     }
 
-    protected class ConstraintDiagnosticResult {
+    protected class ViolatedConsDiagnostic {
         SubtypeConstraint subtypeConstraint;
         AnnotationMirror inferredSubtype;
         AnnotationMirror inferredSupertype;
         List<AnnotationMirror> subtypeSolutions;
         List<AnnotationMirror> supertypeSolutions;
 
-        public ConstraintDiagnosticResult(SubtypeConstraint subtypeConstraint,
+        public ViolatedConsDiagnostic(SubtypeConstraint subtypeConstraint,
                 AnnotationMirror subtype, AnnotationMirror supertype) {
             this.subtypeConstraint = subtypeConstraint;
             this.inferredSubtype = subtype;

--- a/src/ontology/util/OntologyStatisticUtil.java
+++ b/src/ontology/util/OntologyStatisticUtil.java
@@ -1,0 +1,133 @@
+package ontology.util;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.lang.model.element.AnnotationMirror;
+
+import org.checkerframework.javacutil.AnnotationUtils;
+
+import checkers.inference.InferenceMain;
+import ontology.qual.OntologyValue;
+
+public class OntologyStatisticUtil {
+
+    private final static Map<OntologyValue, Integer> valueToHashMap;
+    private final static Map<Integer, OntologyValue> hashToValueMap;
+
+    static {
+        EnumMap<OntologyValue, Integer> tempV2HMap = new EnumMap<> (OntologyValue.class);
+        HashMap<Integer, OntologyValue> tempH2VMap = new HashMap<>();
+
+        int i = 0;
+        for (OntologyValue value : OntologyValue.values()) {
+            tempV2HMap.put(value, Integer.valueOf(i));
+            tempH2VMap.put(Integer.valueOf(i), value);
+            ++ i;
+        }
+        valueToHashMap = Collections.unmodifiableMap(tempV2HMap);
+        hashToValueMap = Collections.unmodifiableMap(tempH2VMap);
+    }
+
+    /**
+     * Persistent general information of inferred slots into file {@code filename}.
+     * Information include:
+     * <ul>
+     *      <li> total number of inferred slots
+     *      <li> inferred slots number of each {@link OntologyValue}
+     * </ul>
+     * @param filename the name of file that will store these information
+     * @param result a map from slot id to inferred annotation result
+     * 
+     * <p><em>Note</em>: file will be stored at the current working directory
+     */
+    public static void writeInferenceResult(String filename, Map<Integer, AnnotationMirror> result) {
+        String writePath = new File(new File("").getAbsolutePath()).toString() + File.separator + filename;
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("total inferred slots number:\t" + result.size() + "\n");
+
+        // get statistic for slots number of each combination of ontology values
+        Map<String, Integer> valuesStatistics = new HashMap<>();
+
+        for (AnnotationMirror inferAnno : result.values()) {
+            if (!AnnotationUtils.areSameIgnoringValues(inferAnno, OntologyUtils.ONTOLOGY)) {
+                InferenceMain.getInstance().logger.warning("OntologyStatisticUtil: found non ontology solution: " + inferAnno);
+                continue;
+            }
+            
+            String hashcode = getHashCode(OntologyUtils.getOntologyValues(inferAnno));
+
+            if (hashcode.isEmpty()) {
+                continue;
+            }
+
+            if (!valuesStatistics.containsKey(hashcode)) {
+                valuesStatistics.put(hashcode, Integer.valueOf(1));
+            } else {
+                valuesStatistics.put(hashcode, valuesStatistics.get(hashcode) + 1);
+            }
+        }
+
+        sb.append("===== ontology values inferred result =====\n");
+
+        for (Map.Entry<String, Integer> entry : valuesStatistics.entrySet()) {
+            OntologyValue[] values = getOntologyValues(entry.getKey());
+            for (int i = 0; i < values.length; i ++ ) {
+                sb.append(values[i].toString());
+                if (i < values.length - 1) {
+                    sb.append(", ");
+                }
+            }
+
+            sb.append("\t" + entry.getValue() + "\n");
+        }
+
+        try {
+            PrintWriter pw = new PrintWriter(writePath);
+            pw.write(sb.toString());
+            pw.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static String getHashCode(OntologyValue... values) {
+        if (values == null || values.length < 1 || values[0] == null) {
+            return new String();
+        }
+
+        List<Integer> list = new ArrayList<> ();
+        for (OntologyValue value : values) {
+            list.add(valueToHashMap.get(value));
+        }
+        Collections.sort(list);
+
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < list.size(); i ++) {
+            sb.append(String.valueOf(list.get(i)));
+            if (i < list.size() - 1) {
+                sb.append(",");
+            }
+        }
+        return sb.toString();
+    }
+
+    private static OntologyValue[] getOntologyValues(String hashcode) {
+        List<OntologyValue> list = new ArrayList<>();
+
+        String[] singleHashs = hashcode.split(",");
+        for (String strHash : singleHashs) {
+            OntologyValue value = hashToValueMap.get(Integer.valueOf(strHash));
+            list.add(value);
+        }
+        return list.toArray(new OntologyValue[list.size()]);
+    }
+}

--- a/src/ontology/util/ViolatedConsDiagnostic.java
+++ b/src/ontology/util/ViolatedConsDiagnostic.java
@@ -1,0 +1,42 @@
+package ontology.util;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.lang.model.element.AnnotationMirror;
+
+import checkers.inference.model.SubtypeConstraint;
+
+public class ViolatedConsDiagnostic {
+        SubtypeConstraint subtypeConstraint;
+        AnnotationMirror inferredSubtype;
+        AnnotationMirror inferredSupertype;
+        List<AnnotationMirror> subtypeSolutions;
+        List<AnnotationMirror> supertypeSolutions;
+
+        public ViolatedConsDiagnostic(SubtypeConstraint subtypeConstraint,
+                AnnotationMirror subtype, AnnotationMirror supertype) {
+            this.subtypeConstraint = subtypeConstraint;
+            this.inferredSubtype = subtype;
+            this.inferredSupertype = supertype;
+            subtypeSolutions = Collections.emptyList();
+            supertypeSolutions = Collections.emptyList();
+        }
+
+        public void setSubtypeSolutions(List<AnnotationMirror> subtypeSolutions) {
+            this.subtypeSolutions = subtypeSolutions;
+        }
+
+        public void setSupertypeSolutions(List<AnnotationMirror> supertypeSolutions) {
+            this.supertypeSolutions = supertypeSolutions;
+        }
+
+        @Override
+        public String toString() {
+            return subtypeConstraint
+                    + "\tsubtype: " + inferredSubtype
+                    + "\tsupertype: " + inferredSupertype
+                    + "\t\n subtypeSolutions: " + subtypeSolutions
+                    + "\t\n supertypeSolutions: " + supertypeSolutions;
+        }
+    }


### PR DESCRIPTION
Major changes:

- add `cronStatistic.sh`, which will downloading projects in `project.data`, and then running ontology on projects with statistic information recorded.

- add `OntologyStatisticUtil`, which will record statistic informations on inferred ontology value.

- add `PostVerificationStatisticRecorder`, which will record post verification statistics (missing inferred constraints number and solution violated constraints number)

Tiny changes:

- small change on ontology value string representation  for getting better format in statistic files.