### PR TITLE
Fixed un-handled case of non-exist JSR308 environment variable when running run-dljc.sh

### DIFF
--- a/run-dljc.sh
+++ b/run-dljc.sh
@@ -2,8 +2,8 @@
 
 WORKING_DIR=$(pwd)
 
-if [ ! -z ${JSR308+x} ] ; then
-    JSR308=$(cd $(dirname "$0")/.. && pwd)
+if [ -z "${JSR308}" ] ; then
+    export JSR308=$(cd $(dirname "$0")/.. && pwd)
 fi
 
 DLJC="$JSR308"/do-like-javac


### PR DESCRIPTION
I've forgot the original script meaning... i.e. (`if [ ! -z ${JSR308+x}]`), and currently it makes no sense to me. Also, when I run `run-dljc.sh` on Vic's machine, it seems this if-statement didn't correctly handle the case when `JSR308` env var doesn't exist.

So, this PR removed the confusing code and changed it to a clearer one: 

if `JSR308` env var doesn't exist, declare one and  set it to a default value.

Tested on Vic machine and it works.

--- Charles 