### PR TITLE
Only pass reachable slots into each backend instance.

### DIFF
--- a/src/ontology/solvers/backend/OntologyConstraintSolver.java
+++ b/src/ontology/solvers/backend/OntologyConstraintSolver.java
@@ -81,15 +81,15 @@ public class OntologyConstraintSolver extends ConstraintSolver {
                 ErrorReporter.errorAbort("vertixSlot should be constantslot!");
             }
 
-            Set<Slot> curSlots = new HashSet<>();
+            Set<Slot> reachableSlots = new HashSet<>();
             for (Constraint constraint : consSet) {
-                curSlots.addAll(constraint.getSlots());
+                reachableSlots.addAll(constraint.getSlots());
             }
 
             addPreferenceToCurBottom((ConstantSlot) entry.getKey().getSlot(), consSet);
             // TODO: is using wildcard here safe?
             Serializer<?, ?> serializer = createSerializer(backEndType, latticeFor2);
-            backEnds.add(createBackEnd(backEndType, configuration, curSlots, consSet,
+            backEnds.add(createBackEnd(backEndType, configuration, reachableSlots, consSet,
                    qualHierarchy, processingEnvironment, latticeFor2, serializer));
         }
 

--- a/src/ontology/solvers/backend/OntologyConstraintSolver.java
+++ b/src/ontology/solvers/backend/OntologyConstraintSolver.java
@@ -81,10 +81,15 @@ public class OntologyConstraintSolver extends ConstraintSolver {
                 ErrorReporter.errorAbort("vertixSlot should be constantslot!");
             }
 
+            Set<Slot> curSlots = new HashSet<>();
+            for (Constraint constraint : consSet) {
+                curSlots.addAll(constraint.getSlots());
+            }
+
             addPreferenceToCurBottom((ConstantSlot) entry.getKey().getSlot(), consSet);
             // TODO: is using wildcard here safe?
             Serializer<?, ?> serializer = createSerializer(backEndType, latticeFor2);
-            backEnds.add(createBackEnd(backEndType, configuration, slots, consSet,
+            backEnds.add(createBackEnd(backEndType, configuration, curSlots, consSet,
                    qualHierarchy, processingEnvironment, latticeFor2, serializer));
         }
 


### PR DESCRIPTION
Instead of passing all slots into each backend instance that solving a sub-graph of all constraints, only passing reachable slots. This makes more sense, and will let us collect more correct statistics about the slots numbers solved by each backend instance. (Currently the statistics of slots number solved is the sum of slot numbers of each backend instances solved).
