### PR TITLE
Remove inferMissingConstraint implementation.

### DIFF
--- a/src/ontology/solvers/backend/OntologyConstraintSolver.java
+++ b/src/ontology/solvers/backend/OntologyConstraintSolver.java
@@ -269,37 +269,12 @@ public class OntologyConstraintSolver extends ConstraintSolver {
                     resultValueSet.toArray(new OntologyValue[resultValueSet.size()]));
             result.put(entry.getKey(), resultAnno);
         }
-        result = inferMissingConstraint(result);
 
         if (collectStatistic) {
             OntologyStatisticUtil.writeInferenceResult("ontology-inferred-slots-statistic.txt", result);
         }
 
         return new DefaultInferenceSolution(result);
-    }
-
-    @Override
-    protected Map<Integer, AnnotationMirror> inferMissingConstraint(Map<Integer, AnnotationMirror> result) {
-        Collection<Constraint> missingConstraints = this.constraintGraph.getMissingConstraints();
-        for (Constraint constraint : missingConstraints) {
-            if (constraint instanceof SubtypeConstraint) {
-                SubtypeConstraint subtypeConstraint = (SubtypeConstraint) constraint;
-                if (!(subtypeConstraint.getSubtype() instanceof ConstantSlot)
-                        && !(subtypeConstraint.getSupertype() instanceof ConstantSlot)) {
-                    VariableSlot subtype = (VariableSlot) subtypeConstraint.getSubtype();
-                    VariableSlot supertype = (VariableSlot) subtypeConstraint.getSupertype();
-                    if (result.keySet().contains(supertype.getId())) {
-                        AnnotationMirror anno = result.get(supertype.getId());
-                        OntologyValue[] ontologyValues = OntologyUtils.getOntologyValues(anno);
-                        if (!(ontologyValues.length == 0 || EnumSet
-                                .copyOf(Arrays.asList(ontologyValues)).contains(OntologyValue.TOP))) {
-                            result.put(subtype.getId(), anno);
-                        }
-                    }
-                }
-            }
-        }
-        return result;
     }
 
     @Override


### PR DESCRIPTION
This inferMissingConstraint implementation has many problems. It infers a missing solution of a slot by the "last" constraint it traversed related to that slot, and doesn't consider the impact of multiple constraints of the same slot. 

For example, for a missing solved slot S, if there were two constraints: C1: "S <: Force" and C2: "S <: Position". If C1 is the last one traversed in this implementation, then S will be inferred as "Force". If C2 is the last one then S will be inferred as "Position". In both cases the inferred result for S is wrong.

I wish to solve this missing constraint problem in a different way, therefore in this PR I remove this implementation.
