### PR TITLE
Refine condition of visiting paraemterizedType for Ontology.

### DIFF
--- a/src/ontology/OntologyInferenceAnnotatedTypeFactory.java
+++ b/src/ontology/OntologyInferenceAnnotatedTypeFactory.java
@@ -136,13 +136,11 @@ public class OntologyInferenceAnnotatedTypeFactory extends InferenceAnnotatedTyp
         @Override
         public Void visitParameterizedType(final ParameterizedTypeTree param, final AnnotatedTypeMirror atm) {
             TreePath path = atypeFactory.getPath(param);
-            if (path != null) {
-                final TreePath parentPath = path.getParentPath();
-                final Tree parentNode = parentPath.getLeaf();
-                if (!parentNode.getKind().equals(Kind.NEW_CLASS)) {
+            if (path == null ||
+                !path.getParentPath().getLeaf().getKind().equals(Kind.NEW_CLASS)) {
                     variableAnnotator.visit(atm, param);
-                }
             }
+
             return null;
         }
     }


### PR DESCRIPTION
The override method `visitParameterizedType` in `OntologyInferenceTreeAnnotator` is from the initial commit of `opprop/Ontology`. I'm guessing  Jason intend to have this override for forbidding `variableAnnotator` visit a ParameterizedTree if the LeafNode of this tree is a NewClassTree.

However, the original implementation is actually forbid `variableAnnotator` visiting in two cases:

 - if the LeafNode of this ParameterizedTree is a NewClassTree
 - or if the TreePath of ParameterizedTree is null

The second case is forbidden accidentally, and should be allowed as the super implementation does.

Test case:

```java
// first file
public class C {
    public void m (MyIterator iter) {
        Object ds = iter.next();
        ds = iter.next();
    }
}
```

```java
// second file, as a class file on the classpath of the first file
import java.util.Iterator;

public interface MyIterator extends Iterator<Object> {
}
```

Forbid second case would cause the VarAnno on the right handle side of the assignment on the 4th line of the first file missing (`iter.next()`).

I still not add this test case into the test suite, as I still not figure out how to add a test case that with another class file on its classpath when doing CF Inference test.

I will add the test case when I figure this out.

  