### PR TITLE
Reasoning about all subtypes of java.util.List to SEQUENCE, instead of hard coding types.

### DIFF
--- a/src/ontology/OntologyAnnotatedTypeFactory.java
+++ b/src/ontology/OntologyAnnotatedTypeFactory.java
@@ -30,7 +30,7 @@ public class OntologyAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     public OntologyAnnotatedTypeFactory(BaseTypeChecker checker) {
         super(checker);
-        OntologyUtils.initOntologyUtils(processingEnv, elements);
+        OntologyUtils.initOntologyUtils(processingEnv);
         postInit();
     }
 
@@ -120,7 +120,7 @@ public class OntologyAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         @Override
         public Void visitNewClass(NewClassTree node, AnnotatedTypeMirror type) {
-            switch (OntologyUtils.determineOntologyValue(type.getUnderlyingType())) {
+            switch (OntologyUtils.getInstance().determineOntologyValue(type.getUnderlyingType())) {
             case SEQUENCE: {
                 AnnotationMirror ontologyValue = OntologyUtils.createOntologyAnnotationByValues(processingEnv, OntologyValue.SEQUENCE);
                 type.replaceAnnotation(ontologyValue);

--- a/src/ontology/OntologyInferenceAnnotatedTypeFactory.java
+++ b/src/ontology/OntologyInferenceAnnotatedTypeFactory.java
@@ -39,7 +39,7 @@ public class OntologyInferenceAnnotatedTypeFactory extends InferenceAnnotatedTyp
             BaseAnnotatedTypeFactory realTypeFactory, InferrableChecker realChecker, SlotManager slotManager,
             ConstraintManager constraintManager) {
         super(inferenceChecker, withCombineConstraints, realTypeFactory, realChecker, slotManager, constraintManager);
-        OntologyUtils.initOntologyUtils(processingEnv, elements);
+        OntologyUtils.initOntologyUtils(processingEnv);
         postInit();
     }
 
@@ -107,7 +107,7 @@ public class OntologyInferenceAnnotatedTypeFactory extends InferenceAnnotatedTyp
 
         @Override
         public Void visitNewClass(final NewClassTree newClassTree, final AnnotatedTypeMirror atm) {
-            switch (OntologyUtils.determineOntologyValue(atm.getUnderlyingType())) {
+            switch (OntologyUtils.getInstance().determineOntologyValue(atm.getUnderlyingType())) {
             case SEQUENCE: {
                 AnnotationMirror anno = OntologyUtils.createOntologyAnnotationByValues(processingEnv, OntologyValue.SEQUENCE);
                 ConstantSlot cs = variableAnnotator.createConstant(anno, newClassTree);


### PR DESCRIPTION
Instead of hard coding what concrete types should be considered as SEQUENCE, catch up a `TypeMirror` of `java.util.List`. Then summarizing all subtype of `List` as SEQUENCE.

Once this PR passed and has been merged, another interesting concept that should be ease to integrate into Ontology is DICTIONARY concept. See: [java.util.Dictionary](https://docs.oracle.com/javase/8/docs/api/java/util/Dictionary.html).